### PR TITLE
Fixing some issues in partnership report, the fixes are listed bellow

### DIFF
--- a/app/admin/partnership_report.rb
+++ b/app/admin/partnership_report.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register_page "Partnership Report" do
   
   controller do
     def index
-      @promotion = Promotion.joins(:partner,:orders).group("promotions.id")
+      @promotion = Promotion.joins(:partner, :orders).group("promotions.id")
       search params[:search]
     end
 

--- a/app/controllers/payment_controller.rb
+++ b/app/controllers/payment_controller.rb
@@ -2,6 +2,7 @@ class PaymentController < ApplicationController
   layout "application"
 
   skip_before_filter :verify_authenticity_token, :only => [:callback_9E93257460]
+  skip_before_filter :filter,                    :only => [:callback_9E93257460]
 
   def credit_card
     return if order_validation_triggered_redirect?(true)
@@ -93,10 +94,11 @@ class PaymentController < ApplicationController
   $.ajax({
    type: "POST",
    url: "/payment/callback_9E93257460",
-   data:  JSON.stringify ({"event": "invoice.status_changed", "data": {"id": "9D92C9E932574604ADD10D327C60D24E", "status": "paid"}}),
+   data:  JSON.stringify ({"event"=>"invoice.status_changed", "data"=>{"id"=>"8DF7CD0B6B9547D69B1E13418B829548", "status"=>"paid"}}),
    contentType: "application/json; charset=utf-8",
    dataType: "json"
   });
+
 =end 
   def callback_9E93257460
 

--- a/app/mailers/notifier.rb
+++ b/app/mailers/notifier.rb
@@ -29,6 +29,7 @@ class Notifier < ActionMailer::Base
 
   def order_completed(order)
     @order = order
+    @order.update_attributes(completed_at: DateTime.now)
     publisher = @order.order_items.first.book.publisher
     mail(from: "#{publisher.name}<#{publisher.contact_email}>", to: order.user.email, subject: I18n.t('notifications.completed.subject'), bbc: "jorge@hedra.com.br")
   end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -31,7 +31,7 @@ class Transaction < ActiveRecord::Base
       where(end_date ? ("transactions.created_at < '#{end_date}'") : "").
       where(user_name.blank? ? "" : "users.name like '%#{user_name}%'").
       where(user_email.blank? ? "" : "users.email like '%#{user_email}%'").
-      order("transactions.user_id, transactions.created_at")
+      order("transactions.created_at desc")
   end
 
   def show_status

--- a/app/reports/promotion_report.rb
+++ b/app/reports/promotion_report.rb
@@ -1,4 +1,4 @@
-class PromotionReport < ActiveRecord::Base
+class PromotionReport
 	
 	def self.details_partners_promotion
 	  result = []

--- a/db/migrate/20160402131618_fill_passed_completed_at_order_field.rb
+++ b/db/migrate/20160402131618_fill_passed_completed_at_order_field.rb
@@ -1,0 +1,12 @@
+class FillPassedCompletedAtOrderField < ActiveRecord::Migration
+  def up
+  	Transaction.completed.find_each do |transaction| 
+  	  if transaction.order.completed_at.blank?
+  	    transaction.order.update_attributes(completed_at: transaction.created_at) 
+  	  end
+  	end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160312012001) do
+ActiveRecord::Schema.define(:version => 20160402131618) do
 
   create_table "active_admin_comments", :force => true do |t|
     t.string   "resource_id",   :null => false


### PR DESCRIPTION
- set completed_at order in notifier, because this isn't set before, the report wasn't working correctly
- add new skip before filter in payment_controller, was blocking auto conciliation transactions for Iugu gateway
- add order by desc created_at in buying report to facilitate search for new buys
- created_at new migration for fill completed_at in all orders that are completed until now